### PR TITLE
Document the installation process via Nixpkgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ A command-line tool that converts TOML to JSON. Nothing more, nothing less.
 $ cargo install toml2json
 ```
 
+### Nixpkgs
+
+```
+nix-env --install toml2json
+```
+
 Please let us know if you package `toml2json` for another package manager or ecosystem!
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ A command-line tool that converts TOML to JSON. Nothing more, nothing less.
 
 ## Installation
 
+### Cargo
+
 ```
 $ cargo install toml2json
 ```


### PR DESCRIPTION
This application is now available on Nixpkgs (see https://github.com/NixOS/nixpkgs/pull/157426). Thus, this PR adds a brief note on how to install `toml2json` via the said package repository.