### PR TITLE
Drop 1.66 MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,18 +19,6 @@ jobs:
           rustup component add clippy
           cargo clippy -- -D warnings
 
-  build-msrv:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Toolchain
-      run: rustup install 1.66.0
-
-    - name: Build
-      run: |
-        cargo +1.66.0 build
-
   build-stable:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ homepage = "https://github.com/woodruffw/toml2json"
 readme = "README.md"
 keywords = ["cli", "toml", "json"]
 categories = ["command-line-utilities", "development-tools", "encoding"]
-rust-version = "1.66"
 
 [package.metadata.release]
 publish = false # handled by GitHub Actions


### PR DESCRIPTION
This is consistently annoying with deps, with no
discernible downstream benefit. Stop it.